### PR TITLE
[IE-55] redundant declaration of sqlContext in zeppelin tutorial

### DIFF
--- a/insightedge-packager/src/main/resources/zeppelin/INSIGHTEDGE-BASIC/note.json
+++ b/insightedge-packager/src/main/resources/zeppelin/INSIGHTEDGE-BASIC/note.json
@@ -447,7 +447,7 @@
       "progressUpdateIntervalMs": 500
     },
     {
-      "title": "Import Spark SQL classes",
+      "title": "Importing Spark SQL classes",
       "text": "%spark\nimport org.apache.spark.sql._\n",
       "dateUpdated": "Apr 20, 2016 6:03:29 AM",
       "config": {


### PR DESCRIPTION
TC Build: http://10.8.1.184:8111/viewType.html?buildTypeId=InsightEdge_Package&branch_InsightEdge=ie-55_remove_redundant_sqlcontext_declaration&tab=buildTypeStatusDiv
