### PR TITLE
GS-13952 Improved lib/required handling

### DIFF
--- a/insightedge-core/src/main/java/org/insightedge/internal/utils/ClassLoaderUtils.java
+++ b/insightedge-core/src/main/java/org/insightedge/internal/utils/ClassLoaderUtils.java
@@ -20,9 +20,9 @@ import com.gigaspaces.start.ClasspathBuilder;
 import com.gigaspaces.start.SystemLocations;
 import org.jini.rio.boot.ServiceClassLoader;
 
-import java.io.File;
-import java.io.FileFilter;
 import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 /**
@@ -46,14 +46,14 @@ public class ClassLoaderUtils {
         return getSparkClassPath(ClassLoaderUtils::sparkJarsFilter);
     }
 
-    public static ClasspathBuilder getSparkClassPath(FileFilter sparkJarsFilter) {
+    public static ClasspathBuilder getSparkClassPath(Predicate<Path> sparkJarsFilter) {
         return new ClasspathBuilder()
-                //.appendPlatform("scala")
-                .append(SystemLocations.singleton().sparkHome().resolve("jars"), sparkJarsFilter);
+                //.appendPlatformJars("scala")
+                .appendJars(SystemLocations.singleton().sparkHome().resolve("jars"), sparkJarsFilter);
     }
 
-    private static boolean sparkJarsFilter(File path) {
-        String jarName = path.getName();
+    private static boolean sparkJarsFilter(Path path) {
+        String jarName = path.getFileName().toString();
         return  !jarName.startsWith("xerces") &&
                 !jarName.startsWith("log4j-") &&
                 !jarName.contains("slf4j-");


### PR DESCRIPTION
Goal is to unify lib/required jars handling by class loader type (system/common/service) instead of inconsistent hueristics (e.g. start with xap-)
- categorize lib/required jars by class loader type on startup.
- added SystemLocations.libRequired(ClassLoaderType) to get relevant paths.
- added ClasspathBuilder.addLibRequired(ClassLoaderType) to simplify class path building.
- refactored ClasspathBuilder.append to appendJars and appendAny to be more explicit on which files are appended.
- modified GsPremiumCommandFactory to use libRequired(System) instead of startsWith("slf4j")
- revamped PUServiceBeanImpl "WEB-INF/lib" construction to be simpler and more efficient.
- modified ClasspathBuilder usages to leverage new cl type functionality and naming